### PR TITLE
Feature/fix memory leak in cache

### DIFF
--- a/tests/Cache.Tests/MemoryCacheBackendTests.cs
+++ b/tests/Cache.Tests/MemoryCacheBackendTests.cs
@@ -54,14 +54,13 @@ namespace Cache.Tests
       }
 
       [Fact]
-      public async Task SetAsync_WithAbsoluteExpirationRelativeToNow_ShouldExpireAfterTime()
+      public async Task SetAsync_WithAbsoluteExpirationAt_ShouldExpireAfterTime()
       {
-         var key = "relative-key";
+         var key = "absolute-at-key";
          var value = "value";
          var expiration = new CacheExpirationOptions
          {
             AbsoluteExpirationAt = DateTimeOffset.UtcNow.AddMilliseconds(200),
-            SlidingExpiration = null,
          };
 
          await this.backend.SetAsync(key, value, expiration, new string[0]);
@@ -83,18 +82,47 @@ namespace Cache.Tests
          await this.backend.SetAsync(key, value, expiration, new string[0]);
          Assert.True(await this.backend.ExistsAsync(key));
 
-         // Act: acceso antes de que expire
+         // Acceso antes de que expire
          await Task.Delay(200);
-         _ = await this.backend.GetAsync(key); // mantenerlo vivo
+         _ = await this.backend.GetAsync(key);
          await Task.Delay(200);
-         _ = await this.backend.GetAsync(key); // volver a mantenerlo vivo
+         _ = await this.backend.GetAsync(key);
 
-         // Assert: aún debe existir
+         // Debe existir aún
          Assert.True(await this.backend.ExistsAsync(key));
 
          // Esperar más allá del tiempo de sliding sin acceder
          await Task.Delay(400);
          Assert.False(await this.backend.ExistsAsync(key));
+      }
+
+      [Fact]
+      public async Task SetAsync_WithMultipleTags_ShouldIndexAllTags()
+      {
+         var key = "multi-tag-key";
+         var value = "value";
+         var tags = new[] { "tag1", "tag2", "tag3" };
+         var expiration = new CacheExpirationOptions();
+
+         await this.backend.SetAsync(key, value, expiration, tags);
+
+         // Verificar que se removió por cada tag
+         await this.backend.RemoveByTagsAsync(new[] { "tag2" });
+         Assert.Null(await this.backend.GetAsync(key));
+      }
+
+      [Fact]
+      public async Task SetAsync_WithDuplicateTags_ShouldHandleDistinctTags()
+      {
+         var key = "duplicate-tags-key";
+         var value = "value";
+         var tags = new[] { "tag1", "tag1", "tag2" };
+         var expiration = new CacheExpirationOptions();
+
+         await this.backend.SetAsync(key, value, expiration, tags);
+
+         var result = await this.backend.GetAsync(key);
+         Assert.Equal(value, result);
       }
 
       [Fact]
@@ -134,6 +162,29 @@ namespace Cache.Tests
       }
 
       [Fact]
+      public async Task RemoveAsync_ShouldCleanupTagIndex()
+      {
+         var key = "key-with-tags";
+         var tags = new[] { "tag1", "tag2" };
+         await this.backend.SetAsync(key, "value", new CacheExpirationOptions(), tags);
+
+         await this.backend.RemoveAsync(key);
+
+         var result = await this.backend.GetAsync(key);
+         Assert.Null(result);
+
+         // Verificar que tags se removieron cuando no hay más keys
+         await this.backend.RemoveByTagsAsync(tags);
+      }
+
+      [Fact]
+      public async Task RemoveAsync_WithNonExistentKey_ShouldNotThrow()
+      {
+         // No debe lanzar excepción
+         await this.backend.RemoveAsync("non-existent-key");
+      }
+
+      [Fact]
       public async Task RemoveByPrefixAsync_ShouldRemoveMatchingKeys()
       {
          await this.backend.SetAsync("prefix-one", "a", new CacheExpirationOptions(), new string[0]);
@@ -145,6 +196,25 @@ namespace Cache.Tests
          Assert.Null(await this.backend.GetAsync("prefix-one"));
          Assert.Null(await this.backend.GetAsync("prefix-two"));
          Assert.NotNull(await this.backend.GetAsync("other"));
+      }
+
+      [Fact]
+      public async Task RemoveByPrefixAsync_ShouldRemoveKeysWithTags()
+      {
+         await this.backend.SetAsync("prefix-key1", "a", new CacheExpirationOptions(), new[] { "tag1" });
+         await this.backend.SetAsync("prefix-key2", "b", new CacheExpirationOptions(), new[] { "tag2" });
+
+         await this.backend.RemoveByPrefixAsync("prefix");
+
+         Assert.Null(await this.backend.GetAsync("prefix-key1"));
+         Assert.Null(await this.backend.GetAsync("prefix-key2"));
+      }
+
+      [Fact]
+      public async Task RemoveByPrefixAsync_NoMatchingKeys_ShouldNotThrow()
+      {
+         // No debe lanzar excepción
+         await this.backend.RemoveByPrefixAsync("nonexistent");
       }
 
       [Fact]
@@ -162,6 +232,37 @@ namespace Cache.Tests
       }
 
       [Fact]
+      public async Task RemoveByTagsAsync_WithMultipleTags_ShouldRemoveUnionOfKeys()
+      {
+         await this.backend.SetAsync("key1", "a", new CacheExpirationOptions(), new[] { "tag1" });
+         await this.backend.SetAsync("key2", "b", new CacheExpirationOptions(), new[] { "tag2" });
+         await this.backend.SetAsync("key3", "c", new CacheExpirationOptions(), new[] { "tag3" });
+
+         await this.backend.RemoveByTagsAsync(new[] { "tag1", "tag2" });
+
+         Assert.Null(await this.backend.GetAsync("key1"));
+         Assert.Null(await this.backend.GetAsync("key2"));
+         Assert.NotNull(await this.backend.GetAsync("key3"));
+      }
+
+      [Fact]
+      public async Task RemoveByTagsAsync_WithDuplicateTags_ShouldHandleDistinct()
+      {
+         await this.backend.SetAsync("key1", "a", new CacheExpirationOptions(), new[] { "tag1" });
+
+         await this.backend.RemoveByTagsAsync(new[] { "tag1", "tag1" });
+
+         Assert.Null(await this.backend.GetAsync("key1"));
+      }
+
+      [Fact]
+      public async Task RemoveByTagsAsync_NonExistentTag_ShouldNotThrow()
+      {
+         // No debe lanzar excepción
+         await this.backend.RemoveByTagsAsync(new[] { "nonexistent-tag" });
+      }
+
+      [Fact]
       public async Task ClearAsync_ShouldRemoveAllCachedItems()
       {
          await this.backend.SetAsync("k1", "v1", new CacheExpirationOptions(), new string[0]);
@@ -173,6 +274,30 @@ namespace Cache.Tests
          Assert.Null(await this.backend.GetAsync("k1"));
          Assert.Null(await this.backend.GetAsync("k2"));
          Assert.Null(await this.backend.GetAsync("k3"));
+      }
+
+      [Fact]
+      public async Task ClearAsync_WithTags_ShouldClearEverything()
+      {
+         await this.backend.SetAsync("k1", "v1", new CacheExpirationOptions(), new[] { "tag1" });
+         await this.backend.SetAsync("k2", "v2", new CacheExpirationOptions(), new[] { "tag2" });
+
+         await this.backend.ClearAsync();
+
+         Assert.Null(await this.backend.GetAsync("k1"));
+         Assert.Null(await this.backend.GetAsync("k2"));
+      }
+
+      [Fact]
+      public async Task GetKeysAsync_ShouldReturnAllKeys()
+      {
+         await this.backend.SetAsync("key1", "v1", new CacheExpirationOptions(), new string[0]);
+         await this.backend.SetAsync("key2", "v2", new CacheExpirationOptions(), new string[0]);
+
+         var keys = await this.backend.GetKeysAsync();
+
+         Assert.Contains("key1", keys);
+         Assert.Contains("key2", keys);
       }
 
       [Fact]
@@ -190,33 +315,88 @@ namespace Cache.Tests
       }
 
       [Fact]
+      public async Task GetKeysAsync_WithEmptyPattern_ShouldReturnAllKeys()
+      {
+         await this.backend.SetAsync("key1", "v1", new CacheExpirationOptions(), new string[0]);
+         await this.backend.SetAsync("key2", "v2", new CacheExpirationOptions(), new string[0]);
+
+         var keys = await this.backend.GetKeysAsync(null);
+
+         Assert.Contains("key1", keys);
+         Assert.Contains("key2", keys);
+      }
+
+      [Fact]
       public async Task GetKeysAsync_ShouldNotReturnExpiredKeys()
       {
          var key = "expired-key";
-         var value = "value";
          var expiration = new CacheExpirationOptions
          {
             AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(100),
          };
 
-         await this.backend.SetAsync(key, value, expiration, new string[0]);
+         await this.backend.SetAsync(key, "value", expiration, new string[0]);
 
-         // Verify key exists initially
          var keysInitial = await this.backend.GetKeysAsync();
          Assert.Contains(key, keysInitial);
 
-         // Wait for expiration
          await Task.Delay(200);
-
-         // Force eviction
          this.memoryCache.Compact(1.0);
-
-         // Give a small window for the callback to execute on the threadpool
          await Task.Delay(50);
 
-         // Verify key is gone from index
          var keysAfter = await this.backend.GetKeysAsync();
          Assert.DoesNotContain(key, keysAfter);
+      }
+
+      [Fact]
+      public async Task EvictionCallback_ShouldCleanupIndicesWhenKeyExpires()
+      {
+         var key = "expiring-key";
+         var tags = new[] { "tag1", "tag2" };
+         var expiration = new CacheExpirationOptions
+         {
+            AbsoluteExpirationRelativeToNow = TimeSpan.FromMilliseconds(100),
+         };
+
+         await this.backend.SetAsync(key, "value", expiration, tags);
+
+         await Task.Delay(200);
+         this.memoryCache.Compact(1.0);
+         await Task.Delay(50);
+
+         // Verificar que las indices se limpiaron
+         var keys = await this.backend.GetKeysAsync();
+         Assert.DoesNotContain(key, keys);
+      }
+
+      [Fact]
+      public async Task SetAsync_ShouldHandleLargeObjects()
+      {
+         var key = "large-object-key";
+         var largeValue = new string('x', 10000);
+         var expiration = new CacheExpirationOptions();
+
+         await this.backend.SetAsync(key, largeValue, expiration, new[] { "tag1" });
+
+         var result = await this.backend.GetAsync(key);
+         Assert.Equal(largeValue, result);
+      }
+
+      [Fact]
+      public async Task SetAsync_OverwriteExistingKey_ShouldUpdateValue()
+      {
+         var key = "overwrite-key";
+         var value1 = "value1";
+         var value2 = "value2";
+         var expiration = new CacheExpirationOptions();
+
+         await this.backend.SetAsync(key, value1, expiration, new[] { "tag1" });
+         var result1 = await this.backend.GetAsync(key);
+         Assert.Equal(value1, result1);
+
+         await this.backend.SetAsync(key, value2, expiration, new[] { "tag2" });
+         var result2 = await this.backend.GetAsync(key);
+         Assert.Equal(value2, result2);
       }
    }
 }

--- a/tests/Cache.Tests/RedisCacheBackendTests.cs
+++ b/tests/Cache.Tests/RedisCacheBackendTests.cs
@@ -465,6 +465,20 @@ namespace Cache.Tests
          this.redisMock.Verify(r => r.KeyDeleteAsync(It.IsAny<RedisKey>(), CommandFlags.None), Times.Once);
       }
 
+      [Fact]
+      public async Task SetAsync_ShouldThrowInvalidOperationException_WhenTypeIsUnsupported()
+      {
+         var key = "unsupported-key";
+         var value = 123; // int is not supported
+         var expiration = new CacheExpirationOptions();
+         var tags = Array.Empty<string>();
+
+         var cacheBackend = new RedisCacheBackend<int>(this.prefix, this.multiplexerMock.Object);
+
+         await Assert.ThrowsAsync<InvalidOperationException>(() =>
+            cacheBackend.SetAsync(key, value, expiration, tags));
+      }
+
       private static IAsyncEnumerable<RedisKey> GetAsyncEnumerable(IEnumerable<RedisKey> keys)
       {
          return new TestAsyncEnumerable<RedisKey>(keys);


### PR DESCRIPTION
A PostEvictionCallback is implemented to ensure that when a cache item expires, its associated keys and tags are properly removed from the tracking indexes (keysIndex, keyToTagsIndex, tagIndex).

This prevents a memory leak where expired keys remained in the indexes indefinitely.